### PR TITLE
Add option to provide a custom dev suffix

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ Declares tasks on the `gulpInst` gulp instance. `options` is an optional object 
        bump: 'Bump release version',
        next: 'Set next development version'
     },
-    packages: ['package.json'] // Supports glob syntax
+    packages: ['package.json'], // Supports glob syntax
+    devSuffix: '-dev' // This is the suffix added for development versions (If not specified, defaults to -dev)
 };
 ```
 

--- a/index.js
+++ b/index.js
@@ -47,7 +47,8 @@ class GitflowRegistry {
     });
     taker.task('bump:next', () => {
       let ver = semver.inc(release.version(), 'patch');
-      return release.bump(ver + '-dev', null, argv.message);
+      let devSuffix = this.options.devSuffix || '-dev';
+      return release.bump(ver + devSuffix, null, argv.message);
     });
 
     function done(cb) {


### PR DESCRIPTION
Our company needed to provide a custom developer suffix (namely -SNAPSHOT) instead of -dev. Would be great if you could add this to the official source.

The suffix is changed using the options object:

```
{
    "messages": ...
    "packages": ...
    "devSuffix": "-SNAPSHOT"
}
```